### PR TITLE
Update go-nd client usage and add api key support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-nd
 
-go 1.24.2
+go 1.25
 
 require (
 	github.com/Jeffail/gabs/v2 v2.7.0
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
 	github.com/looplab/fsm v1.0.3
 	github.com/netascode/go-nd v0.1.3
-	github.com/stretchr/testify v1.10.0
+	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0
 	golang.org/x/net v0.47.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -70,7 +70,7 @@ require (
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
-	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/match v1.2.0 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
@@ -93,3 +93,5 @@ require (
 	google.golang.org/protobuf v1.36.9 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/netascode/go-nd => ../../go/go-nd

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,6 @@ github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/netascode/go-nd v0.1.3 h1:3d7h3fLP+eDUgH5KaQb5EcN/9gwMB+5qdEuxsAdYiCg=
-github.com/netascode/go-nd v0.1.3/go.mod h1:6yqn3s1ZqpxnQghp9JwEEbgKQEfzbEkIlb64TT04cx4=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
@@ -196,13 +194,14 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
-github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/match v1.2.0 h1:0pt8FlkOwjN2fPt4bIl4BoNxb98gGHN2ObFEDkrfZnM=
+github.com/tidwall/match v1.2.0/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=

--- a/internal/provider/nd_provider_gen.go
+++ b/internal/provider/nd_provider_gen.go
@@ -12,6 +12,12 @@ import (
 func NdProviderSchema(ctx context.Context) schema.Schema {
 	return schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			"api_key": schema.StringAttribute{
+				Optional:            true,
+				Sensitive:           true,
+				Description:         "API key for Nexus Dashboard authentication (alternative to password). Environment variable `ND_API_KEY` can be used to override the provider configuration.",
+				MarkdownDescription: "API key for Nexus Dashboard authentication (alternative to password). Environment variable `ND_API_KEY` can be used to override the provider configuration.",
+			},
 			"domain": schema.StringAttribute{
 				Optional:            true,
 				Description:         "NDFC Login credentials - domain. Environment variable `ND_DOMAIN` can be used to override the provider configuration.",
@@ -28,7 +34,7 @@ func NdProviderSchema(ctx context.Context) schema.Schema {
 				MarkdownDescription: "Maximum number of retries for HTTP requests. Environment variable `ND_MAX_RETRIES` can be used to override the provider configuration.",
 			},
 			"password": schema.StringAttribute{
-				Required:            true,
+				Optional:            true,
 				Sensitive:           true,
 				Description:         "NDFC Login credentials - password. Environment variable `ND_PASSWORD` can be used to override the provider configuration.",
 				MarkdownDescription: "NDFC Login credentials - password. Environment variable `ND_PASSWORD` can be used to override the provider configuration.",
@@ -53,6 +59,7 @@ func NdProviderSchema(ctx context.Context) schema.Schema {
 }
 
 type NdModel struct {
+	ApiKey     types.String `tfsdk:"api_key"`
 	Domain     types.String `tfsdk:"domain"`
 	Insecure   types.Bool   `tfsdk:"insecure"`
 	MaxRetries types.Int64  `tfsdk:"max_retries"`

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -91,6 +91,11 @@ func (p *NexusDashboardProvider) Configure(ctx context.Context, req provider.Con
 		config.Password = types.StringValue(password)
 	}
 
+	if config.ApiKey.IsUnknown() || config.ApiKey.IsNull() {
+		apiKey := os.Getenv("ND_API_KEY")
+		config.ApiKey = types.StringValue(apiKey)
+	}
+
 	if config.Domain.IsUnknown() || config.Domain.IsNull() {
 		domain := os.Getenv("ND_DOMAIN")
 		config.Domain = types.StringValue(domain)
@@ -159,12 +164,11 @@ func (p *NexusDashboardProvider) Configure(ctx context.Context, req provider.Con
 		)
 	}
 
-	if config.Password.ValueString() == "" {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("password"),
-			"Missing Nexus Dashboard Password",
-			"The provider cannot create the Nexus Dashboard API client without a password. "+
-				"Set the password value in the configuration or use the ND_PASSWORD environment variable.",
+	if config.Password.ValueString() == "" && config.ApiKey.ValueString() == "" {
+		resp.Diagnostics.AddError(
+			"Missing Nexus Dashboard Credentials",
+			"Either 'password' or 'api_key' must be provided. "+
+				"Set the value in the configuration or use the ND_PASSWORD or ND_API_KEY environment variable.",
 		)
 	}
 
@@ -191,10 +195,17 @@ func (p *NexusDashboardProvider) Configure(ctx context.Context, req provider.Con
 
 	basePath := "/api/v1"
 
+	// Build client options
+	var mods []func(*nd.Client)
+	mods = append(mods, nd.MaxRetries(int(config.MaxRetries.ValueInt64())))
+	mods = append(mods, nd.RequestTimeout(timeout))
+	if config.ApiKey.ValueString() != "" {
+		mods = append(mods, nd.UserApiKey(config.ApiKey.ValueString()))
+	}
+
 	// Create the shared API client
 	client, err := nd.NewClient(url, basePath, username, password,
-		domain, insecure, nd.MaxRetries(int(config.MaxRetries.ValueInt64())),
-		nd.RequestTimeout(timeout))
+		domain, insecure, mods...)
 	if err != nil {
 		tflog.Error(ctx, "Error creating Nexus Dashboard client", map[string]interface{}{"error": err.Error()})
 		resp.Diagnostics.AddError(


### PR DESCRIPTION
## Add API Key Authentication Support to Terraform Provider

### Summary

This PR adds support for user-based API key authentication as an alternative to password-based JWT auth, leveraging the updated `go-nd` client library.

### Changes

#### Provider Schema
- Added `api_key` attribute (optional, sensitive) to the provider configuration
- Changed `password` from required to optional (either `password` or `api_key` must be provided)
- Added `ND_API_KEY` environment variable support

#### Provider Configuration Logic
- Added env var fallback for `ND_API_KEY`
- Updated credential validation: errors only if both `password` and `api_key` are empty
- Passes `nd.UserApiKey(...)` to the `go-nd` client when API key is configured

### Dependencies

This PR requires the updated `go-nd` client ([go-nd PR #23](https://github.com/netascode/go-nd/pull/23)) to be merged first.

### Usage

**Password auth (unchanged):**
```hcl
provider "nd" {
  url      = "https://10.1.1.1"
  username = "admin"
  password = "secret"
}
```

**API key auth (new):**
```hcl
provider "nd" {
  url      = "https://10.1.1.1"
  username = "admin"
  api_key  = "my-api-key"
}
```

**Or via environment variables:**
```bash
export ND_URL="https://10.1.1.1"
export ND_USERNAME="admin"
export ND_API_KEY="my-api-key"
```

### Notes
- Backward compatible — existing configurations with `password` continue to work unchanged
- The `go-nd` update also provides automatic auth endpoint detection (`/api/v1/infra/login` vs `/login`) and token refresh, which work transparently without any provider config changes