### PR TITLE
Fabric common pattern - capability to override crud ops for custom

### DIFF
--- a/internal/Development_Guide.md
+++ b/internal/Development_Guide.md
@@ -748,3 +748,207 @@ The FSM handles deploy via `ConfigSaveAndDeploy`, which acquires `LockDeploy` on
 - [ ] Deploy operations use `ndapi.Acquire(..., ndapi.LockDeploy)` + `DeployPost()`
 - [ ] No `Post()`/`Put()`/`Delete()` calls inside a `LockDeploy` scope (deadlock risk)
 - [ ] Tested concurrent operations to verify no deadlocks or races
+
+---
+
+# Fabric CRUD Handler Pattern (Strategy Registry)
+
+The provider supports multiple fabric types (`vxlan`, `vxlanIbgp`, `vxlanEbgp`, etc.) that share a common CRUD flow. The **Fabric Handler** pattern allows any fabric type to selectively override Create, Read, Update, or Delete without modifying the shared CRUD code or other fabric types.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Fabric Resource (e.g. resource_fabric_vxlan_ebgp)      │
+│    calls RscCreateFabric / RscGetFabric / etc.          │
+└──────────────────────┬──────────────────────────────────┘
+                       │
+                       ▼
+┌─────────────────────────────────────────────────────────┐
+│  resource_fabric_common/fabric_crud.go                  │
+│    RscCreateFabric → fabricHandler(type).Create(...)       │
+│    RscGetFabric    → fabricHandler(type).Read(...)         │
+│    RscUpdateFabric → fabricHandler(type).Update(...)       │
+│    RscDeleteFabric → fabricHandler(type).Delete(...)       │
+└──────────────────────┬──────────────────────────────────┘
+                       │
+            ┌──────────┴──────────┐
+            ▼                     ▼
+   DefaultFabricHandler    Custom handler (registered)
+   (common CRUD flow)      (overrides specific methods)
+```
+
+## Key Interfaces and Types
+
+All defined in `resource_fabric_common/fabric_handlers.go` and `resource_fabric_common/fabric_crud.go`.
+
+### FabricModel
+
+Every fabric type model must implement this interface:
+
+```go
+type FabricModel interface {
+    GetModelData() *NDFCFabricCommonModel
+    SetModelData(*NDFCFabricCommonModel) diag.Diagnostics
+    GetFabricName() string
+    GetFabricType() string   // e.g. "vxlan", "vxlanIbgp", "vxlanEbgp"
+}
+```
+
+`GetFabricType()` is defined in each fabric's `resource_custom_codec.go` and returns a constant string used for handler dispatch.
+
+### FabricPreMarshal / FabricPostUnmarshal (optional)
+
+These are **data-level hooks** on the model, called within the default CRUD flow:
+
+```go
+type FabricPreMarshal interface {
+    PreMarshal(ctx context.Context, data *NDFCFabricCommonModel)
+}
+type FabricPostUnmarshal interface {
+    PostUnmarshal(ctx context.Context, data *NDFCFabricCommonModel)
+}
+```
+
+- **PreMarshal** — adjust model data before POST/PUT (e.g. inject `FabricType` field).
+- **PostUnmarshal** — adjust model data after GET unmarshal (e.g. normalize API quirks).
+
+These are independent from the handler pattern and apply regardless of which handler is active.
+
+### FabricHandler
+
+The strategy interface for CRUD operations:
+
+```go
+type FabricHandler interface {
+    Create(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, model FabricModel)
+    Read(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, model FabricModel)
+    Update(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, model FabricModel)
+    Delete(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, model FabricModel)
+}
+```
+
+### DefaultFabricHandler
+
+Implements `FabricHandler` by delegating to the existing common CRUD logic (`createDefault`, `readDefault`, `updateDefault`, `deleteDefault`):
+
+```go
+type DefaultFabricHandler struct{}
+
+func (DefaultFabricHandler) Create(ctx, client, dg, model) { createDefault(ctx, client, dg, model) }
+func (DefaultFabricHandler) Read(ctx, client, dg, model)   { readDefault(ctx, client, dg, model) }
+func (DefaultFabricHandler) Update(ctx, client, dg, model) { updateDefault(ctx, client, dg, model) }
+func (DefaultFabricHandler) Delete(ctx, client, dg, model) { deleteDefault(ctx, client, dg, model) }
+```
+
+## How Dispatch Works
+
+The public `Rsc*` functions are thin dispatchers:
+
+```go
+func RscCreateFabric(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, model FabricModel) {
+    fabricHandler(model.GetFabricType()).Create(ctx, client, dg, model)
+}
+// same for RscGetFabric, RscUpdateFabric, RscDeleteFabric
+```
+
+`fabricHandler()` looks up the fabric type in a thread-safe registry. If no custom handler is registered, it returns `DefaultFabricHandler{}`.
+
+## Handler Registry
+
+```go
+var (
+    handlersMu sync.RWMutex
+    handlers   = map[string]FabricHandler{}
+)
+
+func RegisterFabricHandler(fabricType string, h FabricHandler) { ... }
+func fabricHandler(fabricType string) FabricHandler { ... }
+```
+
+The registry exists to **break the import cycle**: custom handlers live in per-fabric packages (e.g. `resource_fabric_vxlan_ebgp`) that already import `resource_fabric_common`. A factory switch inside `resource_fabric_common` would create a circular dependency. The registry lets fabric packages self-register without common code knowing about them.
+
+## Default Behavior (No Custom Handler)
+
+If a fabric type does **not** register a custom handler, all CRUD operations use the default common flow. This is the current behavior for all existing fabric types — no changes needed.
+
+## Creating a Custom Handler
+
+To override CRUD operations for a specific fabric type, create a handler in the fabric-specific package.
+
+### Example: Override only Create for vxlanEbgp
+
+```go
+// internal/manage/resource_fabric_vxlan_ebgp/fabric_handler.go
+package resource_fabric_vxlan_ebgp
+
+import (
+    "context"
+
+    "github.com/hashicorp/terraform-plugin-framework/diag"
+    "github.com/netascode/go-nd"
+    "terraform-provider-nd/internal/manage/resource_fabric_common"
+)
+
+func init() {
+    resource_fabric_common.RegisterFabricHandler("vxlanEbgp", vxlanEbgpHandler{})
+}
+
+type vxlanEbgpHandler struct {
+    resource_fabric_common.DefaultFabricHandler // Read, Update, Delete inherited
+}
+
+// Only Create is overridden — Read/Update/Delete use DefaultFabricHandler.
+func (h vxlanEbgpHandler) Create(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, model resource_fabric_common.FabricModel) {
+    // custom pre-create logic here
+    h.DefaultFabricHandler.Create(ctx, client, dg, model) // delegate to default
+    // custom post-create logic here
+}
+```
+
+### Example: Fully replace Delete
+
+```go
+func (h vxlanEbgpHandler) Delete(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, model resource_fabric_common.FabricModel) {
+    // completely custom delete — does NOT call DefaultFabricHandler.Delete
+    fabricName := model.GetFabricName()
+    // ... custom API calls, cleanup, etc.
+}
+```
+
+### Key Points
+
+- **Embed `DefaultFabricHandler`** — you only override methods you need. Unoverridden methods automatically use the default common flow (Go struct embedding).
+- **Register in `init()`** — the handler self-registers when the package is loaded. Since the provider already imports the fabric package (for resource registration), no additional wiring is needed.
+- **One handler per fabric type** — the registry key is the fabric type string returned by `GetFabricType()`.
+- **Full flexibility** — an overridden method can call the default (`h.DefaultFabricHandler.Create(...)`) for pre/post wrapping, or skip it entirely for a full replacement.
+
+## Two Levels of Customization
+
+| Level | Mechanism | Scope | When to use |
+|---|---|---|---|
+| **Data hooks** | `PreMarshal` / `PostUnmarshal` on model | Runs within default CRUD | Inject fields, normalize data |
+| **CRUD override** | Custom `FabricHandler` | Replaces or wraps entire operation | Custom API calls, multi-step flows, skip default |
+
+Most fabric types only need `PreMarshal` (e.g. to inject `FabricType`). The handler pattern is for cases where the **operation itself** needs to change.
+
+## Source Files
+
+| File | Contents |
+|---|---|
+| `resource_fabric_common/fabric_handlers.go` | `FabricHandler` interface, `DefaultFabricHandler`, registry (`RegisterFabricHandler`, `fabricHandler`) |
+| `resource_fabric_common/fabric_crud.go` | `FabricModel` interface, `Rsc*` dispatch functions, `createDefault`/`readDefault`/`updateDefault`/`deleteDefault` |
+| `resource_fabric_vxlan/resource_custom_codec.go` | `GetFabricType() → "vxlan"` |
+| `resource_fabric_vxlan_ibgp/resource_custom_codec.go` | `GetFabricType() → "vxlanIbgp"` |
+| `resource_fabric_vxlan_ebgp/resource_custom_codec.go` | `GetFabricType() → "vxlanEbgp"` |
+
+## Checklist for Adding a Custom Handler
+
+- [ ] Created `fabric_handler.go` in the fabric-specific package
+- [ ] Embedded `resource_fabric_common.DefaultFabricHandler`
+- [ ] Overridden only the CRUD methods that need custom behavior
+- [ ] Called `resource_fabric_common.RegisterFabricHandler` in `init()`
+- [ ] Fabric type string matches `GetFabricType()` return value
+- [ ] Verified build passes (`go build ./...`)
+- [ ] Tested that non-overridden operations still use default flow
+- [ ] Tested that overridden operations execute custom logic

--- a/internal/manage/resource_fabric_common/fabric_crud.go
+++ b/internal/manage/resource_fabric_common/fabric_crud.go
@@ -28,6 +28,7 @@ type FabricModel interface {
 	GetModelData() *NDFCFabricCommonModel
 	SetModelData(*NDFCFabricCommonModel) diag.Diagnostics
 	GetFabricName() string
+	GetFabricType() string
 }
 
 // FabricPreMarshal is an optional interface. Implement it on a fabric model
@@ -46,6 +47,11 @@ type FabricPostUnmarshal interface {
 
 // RscCreateFabric creates a fabric resource via the NDFC API.
 func RscCreateFabric(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, model FabricModel) {
+	fabricHandler(model.GetFabricType()).Create(ctx, client, dg, model)
+}
+
+// createDefault is the built-in create logic.
+func createDefault(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, model FabricModel) {
 	inData := model.GetModelData()
 	if pm, ok := model.(FabricPreMarshal); ok {
 		pm.PreMarshal(ctx, inData)
@@ -79,6 +85,11 @@ func RscCreateFabric(ctx context.Context, client *nd.Client, dg *diag.Diagnostic
 
 // RscGetFabric retrieves fabric information by name and populates the model.
 func RscGetFabric(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, model FabricModel) {
+	fabricHandler(model.GetFabricType()).Read(ctx, client, dg, model)
+}
+
+// readDefault is the built-in read logic.
+func readDefault(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, model FabricModel) {
 	fabricName := model.GetFabricName()
 	tflog.Debug(ctx, "Read fabric", map[string]interface{}{
 		"fabric_name": fabricName,
@@ -111,6 +122,11 @@ func RscGetFabric(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, 
 
 // RscUpdateFabric updates a fabric resource via the NDFC API.
 func RscUpdateFabric(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, model FabricModel) {
+	fabricHandler(model.GetFabricType()).Update(ctx, client, dg, model)
+}
+
+// updateDefault is the built-in update logic.
+func updateDefault(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, model FabricModel) {
 	inData := model.GetModelData()
 	if pm, ok := model.(FabricPreMarshal); ok {
 		pm.PreMarshal(ctx, inData)
@@ -146,8 +162,14 @@ func RscUpdateFabric(ctx context.Context, client *nd.Client, dg *diag.Diagnostic
 	log.Printf("Updated fabric %s with category %s", inData.FabricName, inData.Category)
 }
 
-// RscDeleteFabric deletes a fabric resource by name via the NDFC API.
-func RscDeleteFabric(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, fabricName string) {
+// RscDeleteFabric deletes a fabric resource via the NDFC API.
+func RscDeleteFabric(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, model FabricModel) {
+	fabricHandler(model.GetFabricType()).Delete(ctx, client, dg, model)
+}
+
+// deleteDefault is the built-in delete logic.
+func deleteDefault(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, model FabricModel) {
+	fabricName := model.GetFabricName()
 	fabricAPI := api.NewFabricAPI(client, ndapi.DefaultFabric)
 	fabricAPI.FabricName = fabricName
 	tflog.Debug(ctx, "Delete fabric", map[string]interface{}{

--- a/internal/manage/resource_fabric_common/fabric_handlers.go
+++ b/internal/manage/resource_fabric_common/fabric_handlers.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// SPDX-License-Identifier: MPL-2.0
+
+package resource_fabric_common
+
+import (
+	"context"
+	"sync"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/netascode/go-nd"
+)
+
+// FabricHandler is the strategy interface for fabric CRUD operations.
+// Embed DefaultFabricHandler and override only the methods you need.
+type FabricHandler interface {
+	Create(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, model FabricModel)
+	Read(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, model FabricModel)
+	Update(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, model FabricModel)
+	Delete(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, model FabricModel)
+}
+
+// DefaultFabricHandler implements FabricHandler using the common CRUD flow.
+// Embed it in custom handlers so you only override methods you need.
+type DefaultFabricHandler struct{}
+
+func (DefaultFabricHandler) Create(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, model FabricModel) {
+	createDefault(ctx, client, dg, model)
+}
+func (DefaultFabricHandler) Read(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, model FabricModel) {
+	readDefault(ctx, client, dg, model)
+}
+func (DefaultFabricHandler) Update(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, model FabricModel) {
+	updateDefault(ctx, client, dg, model)
+}
+func (DefaultFabricHandler) Delete(ctx context.Context, client *nd.Client, dg *diag.Diagnostics, model FabricModel) {
+	deleteDefault(ctx, client, dg, model)
+}
+
+// handler registry — keyed by fabric type string (e.g. "vxlanEbgp")
+var (
+	handlersMu sync.RWMutex
+	handlers   = map[string]FabricHandler{}
+)
+
+// RegisterFabricHandler registers a custom handler for a fabric type.
+// Call this from an init() in the fabric-specific package.
+func RegisterFabricHandler(fabricType string, h FabricHandler) {
+	handlersMu.Lock()
+	defer handlersMu.Unlock()
+	handlers[fabricType] = h
+}
+
+// fabricHandler returns the registered handler for the fabric type, or
+// DefaultFabricHandler (common CRUD flow) if none is registered.
+func fabricHandler(fabricType string) FabricHandler {
+	handlersMu.RLock()
+	defer handlersMu.RUnlock()
+	if h, ok := handlers[fabricType]; ok {
+		return h
+	}
+	return DefaultFabricHandler{}
+}

--- a/internal/manage/resource_fabric_vxlan/fabric_vxlan.go
+++ b/internal/manage/resource_fabric_vxlan/fabric_vxlan.go
@@ -163,5 +163,5 @@ func (r *fabricVxlanResource) Delete(ctx context.Context, req resource.DeleteReq
 		"fabric_name": state.FabricName.ValueString(),
 	})
 
-	resource_fabric_common.RscDeleteFabric(ctx, r.manageClient.ApiClient, &resp.Diagnostics, state.FabricName.ValueString())
+	resource_fabric_common.RscDeleteFabric(ctx, r.manageClient.ApiClient, &resp.Diagnostics, &state)
 }

--- a/internal/manage/resource_fabric_vxlan/resource_custom_codec.go
+++ b/internal/manage/resource_fabric_vxlan/resource_custom_codec.go
@@ -12,3 +12,8 @@ package resource_fabric_vxlan
 func (v *FabricVxlanModel) GetFabricName() string {
 	return v.FabricName.ValueString()
 }
+
+// GetFabricType returns the fabric type identifier for handler dispatch.
+func (v *FabricVxlanModel) GetFabricType() string {
+	return "vxlan"
+}

--- a/internal/manage/resource_fabric_vxlan_ebgp/fabric_vxlan_ebgp.go
+++ b/internal/manage/resource_fabric_vxlan_ebgp/fabric_vxlan_ebgp.go
@@ -160,5 +160,5 @@ func (r *fabricVxlanEbgpResource) Delete(ctx context.Context, req resource.Delet
 		"fabric_name": state.FabricName.ValueString(),
 	})
 
-	resource_fabric_common.RscDeleteFabric(ctx, r.manageClient.ApiClient, &resp.Diagnostics, state.FabricName.ValueString())
+	resource_fabric_common.RscDeleteFabric(ctx, r.manageClient.ApiClient, &resp.Diagnostics, &state)
 }

--- a/internal/manage/resource_fabric_vxlan_ebgp/resource_custom_codec.go
+++ b/internal/manage/resource_fabric_vxlan_ebgp/resource_custom_codec.go
@@ -19,6 +19,11 @@ func (v *FabricVxlanEbgpModel) GetFabricName() string {
 	return v.FabricName.ValueString()
 }
 
+// GetFabricType returns the fabric type identifier for handler dispatch.
+func (v *FabricVxlanEbgpModel) GetFabricType() string {
+	return "vxlanEbgp"
+}
+
 // PreMarshal injects the fabric type before the payload is sent to the API.
 // FabricType is tf_hide in the schema, so it must be set here.
 func (v *FabricVxlanEbgpModel) PreMarshal(_ context.Context, data *resource_fabric_common.NDFCFabricCommonModel) {

--- a/internal/manage/resource_fabric_vxlan_ibgp/fabric_vxlan_ibgp.go
+++ b/internal/manage/resource_fabric_vxlan_ibgp/fabric_vxlan_ibgp.go
@@ -160,5 +160,5 @@ func (r *fabricVxlanIbgpResource) Delete(ctx context.Context, req resource.Delet
 		"fabric_name": state.FabricName.ValueString(),
 	})
 
-	resource_fabric_common.RscDeleteFabric(ctx, r.manageClient.ApiClient, &resp.Diagnostics, state.FabricName.ValueString())
+	resource_fabric_common.RscDeleteFabric(ctx, r.manageClient.ApiClient, &resp.Diagnostics, &state)
 }

--- a/internal/manage/resource_fabric_vxlan_ibgp/resource_custom_codec.go
+++ b/internal/manage/resource_fabric_vxlan_ibgp/resource_custom_codec.go
@@ -19,6 +19,11 @@ func (v *FabricVxlanIbgpModel) GetFabricName() string {
 	return v.FabricName.ValueString()
 }
 
+// GetFabricType returns the fabric type identifier for handler dispatch.
+func (v *FabricVxlanIbgpModel) GetFabricType() string {
+	return "vxlanIbgp"
+}
+
 // PreMarshal injects the fabric type before the payload is sent to the API.
 // FabricType is tf_hide in the schema, so it must be set here.
 func (v *FabricVxlanIbgpModel) PreMarshal(_ context.Context, data *resource_fabric_common.NDFCFabricCommonModel) {


### PR DESCRIPTION
Any fabric type can now selectively override CRUD operations by registering a custom handler via init() — embed DefaultFabricHandler, override only the methods you need. All existing fabric types continue using the default common flow with zero changes.